### PR TITLE
Update setup.md

### DIFF
--- a/shizuku/guide/setup.md
+++ b/shizuku/guide/setup.md
@@ -155,7 +155,7 @@ Don't click the dialog shows after connecting the USB, because it will change US
 
 #### GrapheneOS 
 
-The setting "Secure app spawning" may need to be disabled. 
+The Security setting "Secure app spawning" may need to be disabled. 
 Note: GrapheneOS is not an officially supported ROM, but as of January 2023 Shizuku will run on it. 
 
 ### Start via root: cannot start on boot

--- a/shizuku/guide/setup.md
+++ b/shizuku/guide/setup.md
@@ -153,6 +153,11 @@ Do not use the scan feature in MIUI's "Security" app, since it will disable "Dev
 
 Don't click the dialog shows after connecting the USB, because it will change USB usage mode.
 
+#### GrapheneOS 
+
+The setting "Secure app spawning" may need to be disabled. 
+Note: GrapheneOS is not an officially supported ROM, but as of January 2023 Shizuku will run on it. 
+
 ### Start via root: cannot start on boot
 
 Please allow Shizuku to run in the background.


### PR DESCRIPTION
Shizuku would randomly stop running on GrapheneOS (Pixel 7) despite following all directions, fresh installations, etc., until the Graphene-specific security setting "secure app spawning" was disabled. Unclear if this is necessary on all devices, but is a good thing to try for those facing trouble.