### PR TITLE
Fix grammatical error in Shizuku README.md

### DIFF
--- a/shizuku/README.md
+++ b/shizuku/README.md
@@ -30,5 +30,5 @@ public static void grantRuntimePermission(String packageName, String permissionN
 
 ::: tip
 
-There a few more steps to do, like checking permission or if Shizuku is running.
+There's a few more steps to do, like checking permission or if Shizuku is running.
 :::


### PR DESCRIPTION
I noticed that the tip at the bottom of the page says

> There a few more steps to do, like checking permission or if Shizuku is running.

Which has a grammatical error in the very beginning. "There a" doesn't make sense, so I changed it to "There's a", which does make sense.

> There's a few more steps to do, like checking permission or if Shizuku is running.