### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {}
+}```
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "sshKeyName": "your-ssh-key-name",
+    "sshKeyPath": "/path/to/your/ssh/key",
+    "sshAgentConfig": {
+      "enable": true,
+      "socketPath": "/run/user/1000/gnupg/S.gpg-agent"
+    },
+    "dockerCertPath": "/path/to/your/docker/cert",
+    "dockerKeyPath": "/path/to/your/docker/key",
+    "customVolumes": [
+      {
+        "name": "your-custom-volume-name",
+        "containerPath": "/path/to/container/volume",
+        "hostPath": "/path/to/host/volume"
+      }
+    ],
+    "customEnvVars": [
+      {
+        "name": "ENV_VAR_NAME",
+        "value": "ENV_VAR_VALUE"
+      }
+    ],
+    "additionalResources": {
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 8080
+        }
+      ],
+      "additionalPorts": [
+        {
+          "containerPort": 443,
+          "hostPort": 8443
+        }
+      ]
+    }
+  }
+}
+```
+
+Этот пример добавляет следующие дополнительные возможности:
+
+1. **SSH Key Configuration**: Указывает имя и путь к вашему SSH-ключу, а также конфигурацию агента SSH.
+2. **Docker Cert and Key**: Включает путь к вашему сертификату и ключу Docker для безопасной работы с контейнером.
+3. **Custom Volumes**: Позволяет задать пользовательские тома для обмена данными между контейнером и хостом.
+4. **Custom Environment Variables**: Определяет дополнительные переменные окружения, которые будут доступны в контейнере.
+5. **Port Mappings**: Настраивает переадресацию портов для доступа к контейнеру из внешней сети.


### PR DESCRIPTION
Команда `git rev-parse --git-dir` используется для определения пути к каталогу, где установлен Git. Эта команда полезна для скриптов и автоматизированных задач, требующих доступа к внутренним директориям Git.

Пример использования:
```sh
$ git rev-parse --git-dir
```
Эта команда выведет полный путь к каталогу, где установлены репозитории Git. Например, на Windows это может быть `C:\Users\[ваше_имя_пользователя]\.git`, а на Unix-подобных системах — `/home/[ваше_имя_пользователя]/.git`.

Если Git установлен глобально, команда может вернуть путь к каталогу, например:
```sh
$ git rev-parse --git-dir
/usr/local/bin/git
```
В этом случае путь может включать и другие каталоги, такие как `bin` или `share`.

### Параметры команды

Команда `git rev-parse` имеет несколько параметров, которые можно использовать для получения дополнительной информации. Вот некоторые из них:

1. `--show-reflog`: Показывает путь к каталогу, где хранятся записи рефлогов.
   ```sh
   git rev-parse --show-reflog
   ```

2. `--show-toplevel`: Показывает путь к верхнему уровню репозитория.
   ```sh
   git rev-parse --show-toplevel
   ```

3. `--show-working-dir`: Показывает путь к текущему рабочему каталогу.
   ```sh
   git rev-parse --show-working-dir
   ```

4. `--show-config`: Показывает путь к файлу конфигурации Git.
   ```sh
   git rev-parse --show-config
   ```

### Примеры использования

1. Получение пути к каталогу, где установлен Git:
   ```sh
   git rev-parse --git-dir
   ```

2. Получение пути к верхнему уровню репозитория:
   ```sh
   git rev-parse --show-toplevel
   ```

3. Получение пути к текущему рабочему каталогу:
   ```sh
   git rev-parse --show-working-dir
   ```