### PR TITLE
Maybe fix the link in the "The name Shizuku comes from a character." section.

### DIFF
--- a/shizuku/introduction.md
+++ b/shizuku/introduction.md
@@ -2,7 +2,7 @@
 
 Shizuku can help normal apps uses system APIs directly with adb/root privileges with a Java process started with app_process.
 
-The name Shizuku comes from [a character](https://danbooru.donmai.us/posts/3553474).
+The name Shizuku comes from [a character](https://ghibli.fandom.com/wiki/Shizuku_Tsukishima).
 
 ## Why was Shizuku born?
 


### PR DESCRIPTION
I think the character is [Shizuku Tsukishima](https://ghibli.fandom.com/wiki/Shizuku_Tsukishima), so I added a link to her fandom wiki to replace the dead link.