### PR TITLE
Correct image formatting and typo in setup guideline

### DIFF
--- a/shizuku/guide/setup.md
+++ b/shizuku/guide/setup.md
@@ -31,7 +31,8 @@ Starting with wireless debugging works on Android 11 or above. This startup meth
    
 #### Pairing (only needs once)
 
-1. Start pairing in Shizuku<br><img :src="$withBase('/images/start_paring_from_shizuku.png')" style="max-width:320px;width:100%">
+1. Start pairing in Shizuku<br><img :src="$withBase('/images/start_paring_from_shizuku.png')" style="max-![IMG-20251224-WA0003](https://github.com/user-attachments/assets/bc44513f-1921-439b-b208-b94977ed71ff)
+width:320px;width:100%">
 2. [Enable Wireless debugging](#enable-wireless-debugging)
 3. Tap "Pair device with pairing code" in "Wireless debugging"<br><img :src="$withBase('/images/start_pairing.png')" style="max-width:320px;width:100%">
 4. Enter pairing code in Shizuku's notificaiton<br><img :src="$withBase('/images/enter_pairing_code.png')" style="max-width:320px;width:100%">


### PR DESCRIPTION
Fix image tag formatting and correct typo in 'notification'.