### PR TITLE
New option name to disable for Shizuku to work on ColorOS and OxygenOS

### DIFF
--- a/shizuku/guide/setup.md
+++ b/shizuku/guide/setup.md
@@ -129,7 +129,7 @@ Enable "USB debugging (Security options)" in "Developer options". **Note that th
 
 #### ColorOS (OPPO & OnePlus)
 
-Disable "Permission monitoring" in "Developer options".
+Disable "Permission monitoring" or enable "Disable system optimization" in "Developer options".
 
 #### Flyme (Meizu)
 


### PR DESCRIPTION
Since OxygenOS 16.0.7.201 update, "Permission monitoring" option was changed to"Disable system optimization"