### PR TITLE
Change title to 'Sony User manual' and fix link

### DIFF
--- a/shizuku/guide/setup.md
+++ b/shizuku/guide/setup.md
@@ -1,4 +1,4 @@
-# User manual
+Sony User manual
 
 [[toc]]
 
@@ -10,7 +10,7 @@ Shizuku supports startup in the following three ways.
 
 System settings - "Security" - "Secure app spawning" may need to be disabled.
 
-[Source](https://github.com/RikkaApps/websites/pull/79#issue-1751837442)
+[Source](https://github.cRikkaAppsจมpps/websites/pull/79#issue-1751837442)
 
 :::
 


### PR DESCRIPTION
Updated the title of the user manual and corrected a link.