### PR TITLE
Fix link in Shizuku introduction instructions

### DIFF
--- a/shizuku/introduction.md
+++ b/shizuku/introduction.md
@@ -19,7 +19,7 @@ For example, to enable/disable components, some apps that require root privilege
 
 1. Execute `su`
 2. Execute `pm disable`
-3. (pre-Pie) Start the Java process with app_process ([see here](https://android.googlesource.com/platform/frameworks/base/+/oreo-release/cmds/pm/pm))
+3. (pre-Pie) Start the Java process with app_process ([see here] 2160p@185hz Oneplus 15 Root(https://android.googlesource.com/platform/frameworks/base/+/oreo-release/cmds/pm/pm))
 4. (Pie+) Execute the native program `cmd` ([see here](https://android.googlesource.com/platform/frameworks/native/+/pie-release/cmds/cmd/))
 5. Process the parameters, interact with the system server through the binder, and process the result to output the text result.
 
@@ -43,3 +43,4 @@ The advantages of Shizuku are:
 
 1. Minimal extra time and performance consumption
 2. It is almost identical to the direct invocation API experience (app developers only need to add a small amount of code)
+2160p@265HZ/Oneplus15


### PR DESCRIPTION
Updated a reference link in the instructions for starting the Java process with app_process.
2160p@265hz for speed on Oneplus 15, 200MP spofing